### PR TITLE
거리 계산 로직 작성

### DIFF
--- a/src/main/java/com/example/pharmacyrecommendation/direction/entity/Direction.java
+++ b/src/main/java/com/example/pharmacyrecommendation/direction/entity/Direction.java
@@ -1,0 +1,38 @@
+package com.example.pharmacyrecommendation.direction.entity;
+
+import com.example.pharmacyrecommendation.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "direction")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class Direction extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 고객
+    private String inputAddress;
+    private double inputX;
+    private double inputY;
+
+    // 약국
+    private String targetPharmacyName;
+    private double targetX;
+    private double targetY;
+    private String targetAddress;
+
+    // 고객 주소와 약국 주소 사이의 거리
+    private double distance;
+
+}

--- a/src/main/java/com/example/pharmacyrecommendation/direction/service/DirectionService.java
+++ b/src/main/java/com/example/pharmacyrecommendation/direction/service/DirectionService.java
@@ -1,0 +1,78 @@
+package com.example.pharmacyrecommendation.direction.service;
+
+import com.example.pharmacyrecommendation.api.dto.DocumentDto;
+import com.example.pharmacyrecommendation.direction.entity.Direction;
+import com.example.pharmacyrecommendation.pharmacy.dto.PharmacyDto;
+import com.example.pharmacyrecommendation.pharmacy.service.PharmacySearchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DirectionService {
+
+    private static final int MAX_SEARCH_COUNT = 3; // 약국 추천 최대 개수
+    private static final double RADIUS_CUS_KM = 10; // 고객 반경 범위 10km
+
+    private final PharmacySearchService pharmacySearchService;
+
+    public List<Direction> buildDirectionList(DocumentDto documentDto){
+
+        if (Objects.isNull(documentDto)) return Collections.emptyList();
+
+        return pharmacySearchService.searchPharmacyDtoList()
+                .stream().map(pharmacyDto -> Direction.builder()
+                        .inputAddress(documentDto.getAddressName())
+                        .inputX(documentDto.getX())
+                        .inputY(documentDto.getY())
+                        .targetAddress(pharmacyDto.pharmacyAddress())
+                        .targetPharmacyName(pharmacyDto.pharmacyName())
+                        .targetX(pharmacyDto.x())
+                        .targetY(pharmacyDto.y())
+                        .distance(calculateDistanceByHaversine(documentDto.getX(), documentDto.getY(), pharmacyDto.x(), pharmacyDto.y()))
+                        .build())
+                .filter(direction -> direction.getDistance() <= RADIUS_CUS_KM)
+                .sorted(Comparator.comparing(Direction::getDistance))
+                .limit(MAX_SEARCH_COUNT)
+                .toList();
+
+
+
+    }
+
+    // 구면 코사인 법칙
+    private double calculateDistanceBySphericalLawOfCosine(double x1, double y1, double x2, double y2){
+        x1 = Math.toRadians(x1);
+        y1 = Math.toRadians(y1);
+        x2 = Math.toRadians(x2);
+        y2 = Math.toRadians(y2);
+
+        double earthRadius = 6371;
+
+        return earthRadius * Math.acos(Math.sin(y1) * Math.sin(y2) + Math.cos(y1) * Math.cos(y2) * Math.cos(x1 - x2));
+    }
+
+    // Haversine formula
+    private double calculateDistanceByHaversine(double x1, double y1, double x2, double y2){
+        double earthRadius = 6371; // 지구의 반지름 (킬로미터)
+
+        x1 = Math.toRadians(x1);
+        y1 = Math.toRadians(y1);
+        x2 = Math.toRadians(x2);
+        y2 = Math.toRadians(y2);
+
+        double SqSinDeltaY = Math.pow(Math.sin(Math.abs(y2 - y1) / 2), 2);
+        double SqSinDeltaX = Math.pow(Math.sin(Math.abs(x2 - x1) / 2), 2);
+
+        double sqrt = Math.sqrt(SqSinDeltaY + Math.cos(y1) * Math.cos(y2) * SqSinDeltaX);
+
+        return 2 * earthRadius * Math.asin(sqrt);
+    }
+}

--- a/src/main/java/com/example/pharmacyrecommendation/pharmacy/dto/PharmacyDto.java
+++ b/src/main/java/com/example/pharmacyrecommendation/pharmacy/dto/PharmacyDto.java
@@ -1,0 +1,38 @@
+package com.example.pharmacyrecommendation.pharmacy.dto;
+
+import com.example.pharmacyrecommendation.pharmacy.entity.Pharmacy;
+
+public record PharmacyDto(
+        Long id,
+        String pharmacyName,
+        String pharmacyAddress,
+        double x,
+        double y
+) {
+    public PharmacyDto(Long id, String pharmacyName, String pharmacyAddress, double x, double y) {
+        this.id = id;
+        this.pharmacyName = pharmacyName;
+        this.pharmacyAddress = pharmacyAddress;
+        this.x = x;
+        this.y = y;
+    }
+
+    public static PharmacyDto of(Long id, String pharmacyName, String pharmacyAddress, double x, double y) {
+        return new PharmacyDto(id, pharmacyName, pharmacyAddress, x, y);
+    }
+
+    public static PharmacyDto toDto(Pharmacy entity){
+        return PharmacyDto.of(
+                entity.getId(),
+                entity.getPharmacyName(),
+                entity.getPharmacyAddress(),
+                entity.getX(),
+                entity.getY()
+        );
+    }
+
+    public Pharmacy toEntity(){
+        return Pharmacy.of(id, pharmacyName, pharmacyAddress, x, y);
+    }
+
+}

--- a/src/main/java/com/example/pharmacyrecommendation/pharmacy/entity/Pharmacy.java
+++ b/src/main/java/com/example/pharmacyrecommendation/pharmacy/entity/Pharmacy.java
@@ -37,4 +37,7 @@ public class Pharmacy extends BaseTimeEntity {
         this.pharmacyAddress = address;
     }
 
+    public static Pharmacy of(Long id, String pharmacyName, String pharmacyAddress, double x, double y) {
+        return new Pharmacy(id, pharmacyName, pharmacyAddress, x, y);
+    }
 }

--- a/src/main/java/com/example/pharmacyrecommendation/pharmacy/service/PharmacySearchService.java
+++ b/src/main/java/com/example/pharmacyrecommendation/pharmacy/service/PharmacySearchService.java
@@ -1,0 +1,30 @@
+package com.example.pharmacyrecommendation.pharmacy.service;
+
+import com.example.pharmacyrecommendation.pharmacy.dto.PharmacyDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PharmacySearchService {
+
+    private final PharmacyRepositoryService pharmacyRepositoryService;
+
+    public List<PharmacyDto> searchPharmacyDtoList(){
+
+        // redis
+
+        // db
+        return pharmacyRepositoryService.findAll()
+                .stream()
+                .map(PharmacyDto::toDto).toList();
+                // collect(Collectors.toList()) 사용시 수정가능한 ArrayList 반환
+                // toList() 는 수정불가능한 UnModifiableList 반환
+
+    }
+
+}

--- a/src/test/groovy/com/example/pharmacyrecommendation/direction/service/DirectionServiceTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/direction/service/DirectionServiceTest.groovy
@@ -1,0 +1,87 @@
+package com.example.pharmacyrecommendation.direction.service
+
+import com.example.pharmacyrecommendation.api.dto.DocumentDto
+import com.example.pharmacyrecommendation.direction.entity.Direction
+import com.example.pharmacyrecommendation.pharmacy.dto.PharmacyDto
+import com.example.pharmacyrecommendation.pharmacy.service.PharmacySearchService
+import spock.lang.Specification
+
+class DirectionServiceTest extends Specification {
+
+    private PharmacySearchService pharmacySearchService = Mock()
+
+    private DirectionService directionService = new DirectionService(pharmacySearchService)
+
+    private List<PharmacyDto> pharmacyDtoList
+
+    def setup(){
+        pharmacyDtoList = new ArrayList<>()
+        pharmacyDtoList.addAll(
+                PharmacyDto.of(
+                        1L,
+                        "하나로약국",
+                        "서울특별시 강서구 양천로 677",
+                        126.871952248872,
+                        37.5513728079184
+                ),
+                PharmacyDto.of(
+                        2L,
+                        "태평양약국",
+                        "서욽특별시 강서구 등촌로 71",
+                        126.863209505498,
+                        37.5363950714321
+                )
+        )
+    }
+
+    def "buildDirectionList - 결과값이 거리순으로 정렬 되는지 확인"(){
+        given:
+        def addressName = "서울 강서구 양천로75길 57"
+        double inputX = 126.874890556801
+        double inputY = 37.5533141837481
+
+        def documentDto = new DocumentDto(addressName, inputX, inputY);
+
+        when:
+        pharmacySearchService.searchPharmacyDtoList() >> pharmacyDtoList
+        def results = directionService.buildDirectionList(documentDto)
+
+        then:
+        results.size() == 2
+        results.get(0).targetPharmacyName == "하나로약국"
+        results.get(1).targetPharmacyName == "태평양약국"
+        println results.get(0).distance
+        println results.get(1).distance
+    }
+
+    def "buildDirectionList - 정해진 반경(10km) 이내로 검색이 되는지 확인"(){
+
+        given:
+        pharmacyDtoList.add(
+                PharmacyDto.of(
+                        3L,
+                        "세종대학교",
+                        "서울 광진구 능동로 209",
+                        127.07318364213,
+                        37.5516093089619
+                )
+        )
+        def addressName = "서울 강서구 양천로75길 57"
+        double inputX = 126.874890556801
+        double inputY = 37.5533141837481
+
+        def documentDto = new DocumentDto(addressName, inputX, inputY);
+
+        when:
+        pharmacySearchService.searchPharmacyDtoList() >> pharmacyDtoList
+        def results = directionService.buildDirectionList(documentDto)
+
+        then:
+        results.size() == 2
+        results.get(0).targetPharmacyName == "하나로약국"
+        results.get(1).targetPharmacyName == "태평양약국"
+        println results.get(0).distance
+        println results.get(1).distance
+    }
+
+}


### PR DESCRIPTION
Direction이라는 엔티티를 추가해 입력 정보와 db에 있는 약국들 사이의 거리를 구해 저장한다.
거리 계산은 구면 코사인 법칙과 허버사인 공식을 이용하는데, 매우 짧은 거리에서 허버사인 공식이 더 안정적이므로 허버사인 공식을 선택했다.

PharmacyDto를 레코드로 구성하였다. 의미를 가지고 있는 클래스가 아닌 데이터 전달용이므로 레코드를 선택했고, 엔티티를 dto로 변환하는 toDto, dto를 엔티티로 변환하는 toEntity 메소드를 가지고있다. 또한 외부에서 생성자를 통해 생성하지 않고 of라는 static 메소드로 생성할 수 있게 하였다.

DirectionServiceTest에서는 단위 테스트를 진행하였다. 모킹 객체를 의존성 주입한 후 when절에서 모킹 객체의 동작을 정의하였다.