### PR TITLE
KakaoAddressSearchService에 Retry 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,14 @@ dependencies {
     testImplementation "org.testcontainers:mariadb:1.20.4"
     testImplementation "org.testcontainers:spock:1.20.4"
 
+    // spring retry
+    implementation 'org.springframework.retry:spring-retry'
+
+    // mockWebServer
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation 'com.squareup.okhttp3:okhttp:4.12.0'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/pharmacyrecommendation/api/dto/DocumentDto.java
+++ b/src/main/java/com/example/pharmacyrecommendation/api/dto/DocumentDto.java
@@ -2,9 +2,11 @@ package com.example.pharmacyrecommendation.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/example/pharmacyrecommendation/api/dto/MetaDto.java
+++ b/src/main/java/com/example/pharmacyrecommendation/api/dto/MetaDto.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 public class MetaDto {
 
     @JsonProperty("total_count")
-    private String totalCount;
+    private Long totalCount;
 }

--- a/src/main/java/com/example/pharmacyrecommendation/config/RetryConfig.java
+++ b/src/main/java/com/example/pharmacyrecommendation/config/RetryConfig.java
@@ -1,0 +1,16 @@
+package com.example.pharmacyrecommendation.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.support.RetryTemplate;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+
+//    @Bean
+//    public RetryTemplate retryTemplate(){
+//        return new RetryTemplate();
+//    }
+}

--- a/src/test/groovy/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchServiceRetryTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchServiceRetryTest.groovy
@@ -1,0 +1,82 @@
+package com.example.pharmacyrecommendation.api.service
+
+import com.example.pharmacyrecommendation.AbstractIntegrationContainerBaseTest
+import com.example.pharmacyrecommendation.api.dto.DocumentDto
+import com.example.pharmacyrecommendation.api.dto.KakaoAddressSearchApiResponse
+import com.example.pharmacyrecommendation.api.dto.MetaDto
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper
+
+
+import static org.springframework.http.HttpHeaders.*
+
+class KakaoAddressSearchServiceRetryTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private KakaoAddressSearchService kakaoAddressSearchService
+
+    @SpringBean
+    private KakaoUriBuilderService kakaoUriBuilderService = Mock()
+
+    private MockWebServer mockWebServer
+
+    private ObjectMapper mapper = new ObjectMapper()
+
+    private String inputAddress = "서울 강서구 공항대로 519"
+
+    def setup(){
+        mockWebServer = new MockWebServer()
+        mockWebServer.start()
+        println mockWebServer.port
+        println mockWebServer.url("/")
+    }
+
+    def cleanup(){
+        mockWebServer.shutdown()
+    }
+
+    def "requestAddressSearch retry success"(){
+        given:
+        def metaDto = new MetaDto(1)
+        def documentDto = DocumentDto.builder()
+            .addressName(inputAddress)
+            .build()
+        def expectResponse = new KakaoAddressSearchApiResponse(metaDto, Arrays.asList(documentDto))
+        def uri = mockWebServer.url("/").uri()
+
+        when:
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+            .addHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .setBody(mapper.writeValueAsString(expectResponse)))
+
+        def kakaoApiResult = kakaoAddressSearchService.requestAddressSearch(inputAddress)
+
+        then:
+        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
+        kakaoApiResult.getDocumentDtoList().size() == 1
+        kakaoApiResult.getMetaDto().totalCount == 1
+        kakaoApiResult.getDocumentDtoList().get(0).getAddressName() == inputAddress
+
+    }
+
+    def "requestAddressSearch retry fail"(){
+        given:
+        def uri = mockWebServer.url("/").uri()
+
+        when:
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+
+        def result = kakaoAddressSearchService.requestAddressSearch(inputAddress)
+
+        then:
+        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
+        result == null
+    }
+
+}


### PR DESCRIPTION
retry를 적용해 에러가 날 때 재시도 하도록 한다.

MockWebServer를 통해 테스트하였는데, 테스트 진행 방식에 의문점이 생겼다.
모킹한 kakaoUriBuilerService의 buildUriByAddressSearch 행동을 then절에서 정의한 것 같은데 when절에서 이미 kakaoAddressSearchService의 requestAddressSearch를 호출하였다. 진행이 어떻게 되는건지 추후에 공부하여 코멘트 남길 것.