### PR TITLE
카테고리 기준으로 장소를 찾는 api를 사용하도록 변경

### DIFF
--- a/src/main/java/com/example/pharmacyrecommendation/api/dto/DocumentDto.java
+++ b/src/main/java/com/example/pharmacyrecommendation/api/dto/DocumentDto.java
@@ -12,9 +12,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class DocumentDto {
 
+    @JsonProperty("place_name")
+    private String placeName;
+
     @JsonProperty("address_name")
     private String addressName;
 
     private double x;
     private double y;
+
+    private double distance;
 }

--- a/src/main/java/com/example/pharmacyrecommendation/api/service/KakaoCategorySearchService.java
+++ b/src/main/java/com/example/pharmacyrecommendation/api/service/KakaoCategorySearchService.java
@@ -1,0 +1,41 @@
+package com.example.pharmacyrecommendation.api.service;
+
+import com.example.pharmacyrecommendation.api.dto.KakaoAddressSearchApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoCategorySearchService {
+
+    private final KakaoUriBuilderService kakaoUriBuilderService;
+
+    private final RestTemplate restTemplate;
+
+    private static final String PHARMACY_CATEGORY = "PM9";
+
+    @Value("${kakao.rest.api.key}")
+    private String kakaoRestApiKey;
+
+    public KakaoAddressSearchApiResponse requestPharmacyCategorySearch(double x, double y, double radius){
+
+        URI uri = kakaoUriBuilderService.builderUriByCategorySearch(x, y, radius, PHARMACY_CATEGORY);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey);
+        HttpEntity httpEntity = new HttpEntity<>(headers);
+
+        return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoAddressSearchApiResponse.class).getBody();
+
+    }
+
+}

--- a/src/main/java/com/example/pharmacyrecommendation/api/service/KakaoUriBuilderService.java
+++ b/src/main/java/com/example/pharmacyrecommendation/api/service/KakaoUriBuilderService.java
@@ -11,6 +11,8 @@ import java.net.URI;
 public class KakaoUriBuilderService {
 
     private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+    private static final String KAKAO_LOCAL_CATEGORY_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/category.json";
+
 
     public URI buildUriByAddressSearch(String address){
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
@@ -20,6 +22,24 @@ public class KakaoUriBuilderService {
         //log.info("[KakaoUriBuilderService][buildUriByAddressSearch] address: {}, uri: {}", address, uri);
 
         return uri;
+    }
+
+    public URI builderUriByCategorySearch(double x, double y, double radius, String category){
+
+        double meterRadius = radius * 1000;
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(KAKAO_LOCAL_CATEGORY_SEARCH_URL);
+        builder.queryParam("category_group_code", category);
+        builder.queryParam("x", x);
+        builder.queryParam("y", y);
+        builder.queryParam("radius", meterRadius);
+        builder.queryParam("sort", "distance");
+
+        URI uri = builder.build().encode().toUri();
+        //log.info("[KakaoUriBuilderService][builderUriByCategorySearch] uri: {}", uri);
+
+        return uri;
+
     }
 
 }

--- a/src/main/java/com/example/pharmacyrecommendation/pharmacy/service/PharmacyRecommendationService.java
+++ b/src/main/java/com/example/pharmacyrecommendation/pharmacy/service/PharmacyRecommendationService.java
@@ -35,7 +35,8 @@ public class PharmacyRecommendationService {
 
         DocumentDto documentDto = response.getDocumentDtoList().get(0);
 
-        List<Direction> directionList = directionService.buildDirectionList(documentDto);
+        //List<Direction> directionList = directionService.buildDirectionList(documentDto);
+        List<Direction> directionList = directionService.buildDirectionListByCategoryApi(documentDto);
 
         directionService.saveAll(directionList);
 

--- a/src/test/groovy/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchServiceTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchServiceTest.groovy
@@ -1,7 +1,6 @@
 package com.example.pharmacyrecommendation.api.service
 
 import com.example.pharmacyrecommendation.AbstractIntegrationContainerBaseTest
-import com.example.pharmacyrecommendation.api.dto.KakaoAddressSearchApiResponse
 import org.springframework.beans.factory.annotation.Autowired
 
 class KakaoAddressSearchServiceTest extends AbstractIntegrationContainerBaseTest {

--- a/src/test/groovy/com/example/pharmacyrecommendation/direction/service/DirectionServiceTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/direction/service/DirectionServiceTest.groovy
@@ -1,7 +1,6 @@
 package com.example.pharmacyrecommendation.direction.service
 
 import com.example.pharmacyrecommendation.api.dto.DocumentDto
-import com.example.pharmacyrecommendation.direction.entity.Direction
 import com.example.pharmacyrecommendation.pharmacy.dto.PharmacyDto
 import com.example.pharmacyrecommendation.pharmacy.service.PharmacySearchService
 import spock.lang.Specification

--- a/src/test/java/com/example/pharmacyrecommendation/direction/service/DirectionServiceCategoryApiTest.java
+++ b/src/test/java/com/example/pharmacyrecommendation/direction/service/DirectionServiceCategoryApiTest.java
@@ -1,0 +1,40 @@
+package com.example.pharmacyrecommendation.direction.service;
+
+import com.example.pharmacyrecommendation.api.dto.DocumentDto;
+import com.example.pharmacyrecommendation.direction.entity.Direction;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class DirectionServiceCategoryApiTest {
+
+    @Autowired
+    private DirectionService directionService;
+
+    @Test
+    void buildDirectionListByCategoryApi_isReturnedCorrectly() {
+        //given
+        DocumentDto documentDto = DocumentDto.builder()
+                .x(126.874890556801)
+                .y(37.5533141837481)
+                .addressName("서울 강서구 양천로75길 57")
+                .build();
+        //when
+        List<Direction> directionList = directionService.buildDirectionListByCategoryApi(documentDto);
+
+        //then
+
+        // 리턴 결과 3개인지 확인
+        assertThat(directionList.size()).isEqualTo(3);
+        // 리턴 결과 정렬 확인
+        assertThat(directionList.get(0).getDistance()).isLessThan(directionList.get(1).getDistance());
+        // 리턴 결과 반경 2km 이내인지 확인
+        assertThat(directionList).allMatch(direction -> direction.getDistance() <= 2);
+
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: groovyTest
+    active: javaTest
     group:
       groovyTest:
         - common


### PR DESCRIPTION
-약국 데이터를 db에 저장해두지 않음. -> 약국의 정보가 변경되어도 정적인 데이터를 사용하지 않으므로 유연해짐
-거리 계산 직접 하지 않음. -> 계산된 거리가 응답으로 들어와 dto에서 받아주기만 하면 됨
-정렬, 기준 반경에 대한 필터링된 데이터가 응답 -> 응답 리스트 중 앞의 3개만 사용하면 됨