### PR TITLE
shorten url 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     // thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
+    // base62 encoding
+    implementation 'io.seruco.encoding:base62:0.1.3'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/pharmacyrecommendation/direction/controller/DirectionController.java
+++ b/src/main/java/com/example/pharmacyrecommendation/direction/controller/DirectionController.java
@@ -1,0 +1,29 @@
+package com.example.pharmacyrecommendation.direction.controller;
+
+import com.example.pharmacyrecommendation.direction.entity.Direction;
+import com.example.pharmacyrecommendation.direction.service.DirectionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RequiredArgsConstructor
+@Slf4j
+@Controller
+public class DirectionController {
+
+    private final DirectionService directionService;
+
+    @GetMapping("/dir/{encodedId}")
+    public String searchDirection(@PathVariable("encodedId") String encodedID){
+        return "redirect:" + directionService.findDirectionUrl(encodedID);
+    }
+
+    @GetMapping("/road/{encodedId}")
+    public String searchRoadView(@PathVariable("encodedId") String encodedID){
+        return "redirect:" +  directionService.findRoadViewUrl(encodedID);
+    }
+
+}

--- a/src/main/java/com/example/pharmacyrecommendation/direction/dto/OutputDto.java
+++ b/src/main/java/com/example/pharmacyrecommendation/direction/dto/OutputDto.java
@@ -1,9 +1,8 @@
 package com.example.pharmacyrecommendation.direction.dto;
 
-
 import com.example.pharmacyrecommendation.direction.entity.Direction;
+import com.example.pharmacyrecommendation.direction.service.Base62Service;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 public record OutputDto(
@@ -14,8 +13,8 @@ public record OutputDto(
         String distance
 ) {
 
-    public static final String DIRECTION_BASE_URL = "https://map.kakao.com/link/to/";
-    public static final String ROAD_VIEW_BASE_URL = "https://map.kakao.com/link/roadview/";
+    public static String DIRECTION_BASE_URL = "http://localhost:8080/dir/";
+    public static String ROAD_VIEW_BASE_URL = "http://localhost:8080/road/";
 
     public OutputDto(String pharmacyName, String pharmacyAddress, String directionUrl, String roadViewUrl, String distance) {
         this.pharmacyName = pharmacyName;
@@ -35,17 +34,14 @@ public record OutputDto(
 
     public static OutputDto toDto(Direction direction){
 
-        String params = String.join(",",
-                direction.getTargetPharmacyName(), String.valueOf(direction.getTargetY()), String.valueOf(direction.getTargetX()));
-
-        String directionUrl = UriComponentsBuilder.fromUriString(DIRECTION_BASE_URL + params).toUriString();
-        log.info("direction url : {}", directionUrl);
+        Base62Service base62Service = new Base62Service();
+        String encodedId = base62Service.encodeDirectionId(direction.getId());
 
         return OutputDto.of(
                 direction.getTargetPharmacyName(),
                 direction.getTargetAddress(),
-                directionUrl,
-                ROAD_VIEW_BASE_URL + direction.getTargetY() + "," + direction.getTargetX(),
+                DIRECTION_BASE_URL + encodedId,
+                ROAD_VIEW_BASE_URL + encodedId,
                 String.format("%.2f km",direction.getDistance())
         );
     }

--- a/src/main/java/com/example/pharmacyrecommendation/direction/service/Base62Service.java
+++ b/src/main/java/com/example/pharmacyrecommendation/direction/service/Base62Service.java
@@ -1,0 +1,20 @@
+package com.example.pharmacyrecommendation.direction.service;
+
+import io.seruco.encoding.base62.Base62;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class Base62Service {
+    private final Base62 base62Instance = Base62.createInstance();
+
+    public String encodeDirectionId(Long directionId){
+        return new String(base62Instance.encode(String.valueOf(directionId).getBytes()));
+    }
+
+    public Long decodeDirectionId(String encodedDirectionId){
+        String resultDirectionId = new String(base62Instance.decode(encodedDirectionId.getBytes()));
+        return Long.valueOf(resultDirectionId);
+    }
+}

--- a/src/test/groovy/com/example/pharmacyrecommendation/direction/controller/DirectionControllerTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/direction/controller/DirectionControllerTest.groovy
@@ -1,0 +1,39 @@
+package com.example.pharmacyrecommendation.direction.controller
+
+import com.example.pharmacyrecommendation.direction.service.DirectionService
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import spock.lang.Specification
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+class DirectionControllerTest extends Specification {
+
+    private MockMvc mockMvc
+    private DirectionService directionService = Mock()
+
+    def setup(){
+        mockMvc = MockMvcBuilders.standaloneSetup(new DirectionController(directionService))
+            .build()
+    }
+
+    def "GET /dir/{encodedId}"(){
+        given:
+        String encodedId = "r"
+
+        String redirectURL = "https://map.kakao.com/link/map/pharmacy,38.11,128.11"
+
+        when:
+        directionService.findDirectionUrl(encodedId) >> redirectURL
+
+        def result = mockMvc.perform(MockMvcRequestBuilders.get("/dir/{encodedId}", encodedId))
+
+        then:
+        result.andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(redirectURL))
+            .andDo(print())
+    }
+
+}

--- a/src/test/groovy/com/example/pharmacyrecommendation/direction/service/Base62ServiceTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/direction/service/Base62ServiceTest.groovy
@@ -1,0 +1,25 @@
+package com.example.pharmacyrecommendation.direction.service
+
+import spock.lang.Specification
+
+class Base62ServiceTest extends Specification {
+
+    private Base62Service base62Service;
+
+    def setup(){
+        base62Service = new Base62Service()
+    }
+
+    def "check base62 encoder/decoder"(){
+        given:
+        long num = 5
+
+        when:
+        def encoded = base62Service.encodeDirectionId(num)
+        def decoded = base62Service.decodeDirectionId(encoded)
+
+        then:
+        num == decoded
+    }
+
+}

--- a/src/test/groovy/com/example/pharmacyrecommendation/direction/service/DirectionServiceTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/direction/service/DirectionServiceTest.groovy
@@ -1,6 +1,8 @@
 package com.example.pharmacyrecommendation.direction.service
 
 import com.example.pharmacyrecommendation.api.dto.DocumentDto
+import com.example.pharmacyrecommendation.api.service.KakaoCategorySearchService
+import com.example.pharmacyrecommendation.direction.repository.DirectionRepository
 import com.example.pharmacyrecommendation.pharmacy.dto.PharmacyDto
 import com.example.pharmacyrecommendation.pharmacy.service.PharmacySearchService
 import spock.lang.Specification
@@ -8,8 +10,12 @@ import spock.lang.Specification
 class DirectionServiceTest extends Specification {
 
     private PharmacySearchService pharmacySearchService = Mock()
+    private DirectionRepository directionRepository = Mock()
+    private KakaoCategorySearchService kakaoCategorySearchService = Mock()
 
-    private DirectionService directionService = new DirectionService(pharmacySearchService)
+    private DirectionService directionService = new DirectionService(
+            kakaoCategorySearchService, pharmacySearchService, directionRepository
+    )
 
     private List<PharmacyDto> pharmacyDtoList
 
@@ -39,21 +45,24 @@ class DirectionServiceTest extends Specification {
         double inputX = 126.874890556801
         double inputY = 37.5533141837481
 
-        def documentDto = new DocumentDto(addressName, inputX, inputY);
+        def documentDto = DocumentDto.builder()
+            .addressName(addressName)
+            .x(inputX)
+            .y(inputY)
+            .build()
 
         when:
         pharmacySearchService.searchPharmacyDtoList() >> pharmacyDtoList
         def results = directionService.buildDirectionList(documentDto)
 
         then:
-        results.size() == 2
+        // 하나는 반경 밖에 있음
+        results.size() == 1
         results.get(0).targetPharmacyName == "하나로약국"
-        results.get(1).targetPharmacyName == "태평양약국"
         println results.get(0).distance
-        println results.get(1).distance
     }
 
-    def "buildDirectionList - 정해진 반경(10km) 이내로 검색이 되는지 확인"(){
+    def "buildDirectionList - 정해진 반경(2km) 이내로 검색이 되는지 확인"(){
 
         given:
         pharmacyDtoList.add(
@@ -69,18 +78,20 @@ class DirectionServiceTest extends Specification {
         double inputX = 126.874890556801
         double inputY = 37.5533141837481
 
-        def documentDto = new DocumentDto(addressName, inputX, inputY);
+        def documentDto = DocumentDto.builder()
+                .addressName(addressName)
+                .x(inputX)
+                .y(inputY)
+                .build()
 
         when:
         pharmacySearchService.searchPharmacyDtoList() >> pharmacyDtoList
         def results = directionService.buildDirectionList(documentDto)
 
         then:
-        results.size() == 2
+        results.size() == 1
         results.get(0).targetPharmacyName == "하나로약국"
-        results.get(1).targetPharmacyName == "태평양약국"
         println results.get(0).distance
-        println results.get(1).distance
     }
 
 }

--- a/src/test/java/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchServiceDataImportTest.java
+++ b/src/test/java/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchServiceDataImportTest.java
@@ -3,6 +3,7 @@ package com.example.pharmacyrecommendation.api.service;
 import com.example.pharmacyrecommendation.api.dto.KakaoAddressSearchApiResponse;
 import com.example.pharmacyrecommendation.pharmacy.entity.Pharmacy;
 import com.example.pharmacyrecommendation.pharmacy.repository.PharmacyRepository;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.List;
 
 
+@Disabled
 @SpringBootTest
 class KakaoAddressSearchServiceDataImportTest {
 

--- a/src/test/java/com/example/pharmacyrecommendation/direction/service/DirectionServiceCategoryApiTest.java
+++ b/src/test/java/com/example/pharmacyrecommendation/direction/service/DirectionServiceCategoryApiTest.java
@@ -2,6 +2,7 @@ package com.example.pharmacyrecommendation.direction.service;
 
 import com.example.pharmacyrecommendation.api.dto.DocumentDto;
 import com.example.pharmacyrecommendation.direction.entity.Direction;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -10,6 +11,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 
+@Disabled
 @SpringBootTest
 class DirectionServiceCategoryApiTest {
 


### PR DESCRIPTION
결과값의 url이 많이 길기 때문에 shorten url을 사용하도록 변경하였다.

url은 최종 결과인 directionList의 각 direction의 id를 base62로 인코딩한 후 shorten url을 구성하여 제공한다.

해당 url을 누르면 카카오 지도 길찾기 서비스 또는 로드뷰 서비스로 redirect 된다.